### PR TITLE
删除已不存在security项目以同步上游并修复错误

### DIFF
--- a/Boat/src/main/jni/CMakeLists.txt
+++ b/Boat/src/main/jni/CMakeLists.txt
@@ -3,4 +3,3 @@ cmake_minimum_required(VERSION 3.4.1)
 # include libs
 ADD_SUBDIRECTORY(boat/)
 ADD_SUBDIRECTORY(loadme/)
-ADD_SUBDIRECTORY(security/)

--- a/Boat/src/main/jni/security/CMakeLists.txt
+++ b/Boat/src/main/jni/security/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.4.1)
-
-set(INCLUDE_DIR . ../boat/ ../boat/include/)
-
-add_library(security SHARED security.cpp)
-include_directories(${INCLUDE_DIR})
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -O2 -Wall -Werror")
-target_link_libraries(security log)


### PR DESCRIPTION
在上游项目中，security文件夹已不再存在，请将其删除。同时，由于此文件夹中cpp文件的缺失，当前项目无法编译。